### PR TITLE
[TECHNICAL SUPPORT] LPS-34764 Fixed _totalSize setting for large file sizes

### DIFF
--- a/portal-impl/src/com/liferay/portal/upload/LiferayInputStream.java
+++ b/portal-impl/src/com/liferay/portal/upload/LiferayInputStream.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.servlet.ServletInputStreamAdapter;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ProgressTracker;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsUtil;
 
 import java.io.IOException;
@@ -37,7 +38,7 @@ import javax.servlet.http.HttpSession;
  */
 public class LiferayInputStream extends ServletInputStreamAdapter {
 
-	public static final int THRESHOLD_SIZE = GetterUtil.getInteger(
+	public static final long THRESHOLD_SIZE = GetterUtil.getInteger(
 		PropsUtil.get(LiferayInputStream.class.getName() + ".threshold.size"));
 
 	public LiferayInputStream(HttpServletRequest request) throws IOException {
@@ -45,6 +46,14 @@ public class LiferayInputStream extends ServletInputStreamAdapter {
 
 		_session = request.getSession();
 		_totalSize = request.getContentLength();
+
+		if (_totalSize < 0) {
+			String contentLength = request.getHeader("content-length");
+
+			if (Validator.isNotNull(contentLength)) {
+				_totalSize = Long.parseLong(contentLength);
+			}
+		}
 	}
 
 	public ServletInputStream getCachedInputStream() {
@@ -107,7 +116,7 @@ public class LiferayInputStream extends ServletInputStreamAdapter {
 	private UnsyncByteArrayOutputStream _cachedBytes =
 		new UnsyncByteArrayOutputStream();
 	private HttpSession _session;
-	private int _totalRead;
-	private int _totalSize;
+	private long _totalRead;
+	private long _totalSize;
 
 }


### PR DESCRIPTION
Hi Zsigmond,

This fix handles extreme large file sizes where file size doesn't fit in the Integer.MAX_VALUE. Hence the API cannot give it back as it will overflow and the request.getContentLenght() will return -1 instead of the size of the file. The only solution I found is to retreive the size from the header "content-length" and store it as long.

Regards,
Vilmos
